### PR TITLE
add support for variable.language

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -84,6 +84,10 @@ atom-text-editor.is-focused .line.cursor-line,
   font-style: italic;
 }
 
+.variable.language {
+  color: @syntax-variable-color;
+}
+
 .constant.numeric {
   color: @syntax-variable-color;
 }


### PR DESCRIPTION
I really like the colors of this syntax theme. I work mostly in python and it uses variable.language as the harbor for things like the class built-in variable `self`.

Can we get this added as highlighting as a variable?
